### PR TITLE
defconfig: disable samsung anti-root drivers (Hypervisor)

### DIFF
--- a/arch/arm64/configs/s5e8825-m34xnsxx_defconfig
+++ b/arch/arm64/configs/s5e8825-m34xnsxx_defconfig
@@ -525,11 +525,6 @@ CONFIG_ARCH_ENABLE_THP_MIGRATION=y
 #
 # Hypervisor
 #
-CONFIG_UH=y
-CONFIG_RKP=y
-CONFIG_KDP=y
-CONFIG_KDP_CRED=y
-CONFIG_KDP_NS=y
 # end of Hypervisor
 
 #


### PR DESCRIPTION
If KernelSU is enabled, UH will detect it and then shut it down. Its better to remove it entirely.